### PR TITLE
Fix Linux/macOS compatibility issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,7 +17,11 @@ from scripts.wifi_cracking_script import automated_wifi_attack
 from scripts.payload_generation_script import payload_script
 def main():
     systemtype = platform.system()
-    user = os.getlogin()
+    try:
+        user = os.getlogin()
+    except OSError:
+        import getpass
+        user = getpass.getuser()
     mac_install()
     check_and_install_dependencies()
 

--- a/scripts/antivirus_check_script.py
+++ b/scripts/antivirus_check_script.py
@@ -1,9 +1,38 @@
 import os
+import platform
+import subprocess
 
 
 def is_av_active():
-    try:
+    systemtype = platform.system()
 
-        return os.system('sc query WinDefend | find "RUNNING"') == 0
-    except:
-        return False
+    if systemtype == "Windows":
+        try:
+            return os.system('sc query WinDefend | find "RUNNING"') == 0
+        except Exception:
+            return False
+
+    elif systemtype == "Linux":
+        try:
+            for service in ("clamav-daemon", "clamav-freshclam"):
+                result = subprocess.run(
+                    ["systemctl", "is-active", "--quiet", service]
+                )
+                if result.returncode == 0:
+                    return True
+            return False
+        except Exception:
+            return False
+
+    elif systemtype == "Darwin":
+        try:
+            result = subprocess.run(
+                ["pgrep", "-x", "XProtectService"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    return False

--- a/scripts/dependencies_install_script.py
+++ b/scripts/dependencies_install_script.py
@@ -4,12 +4,17 @@ import sys
 import requests
 import subprocess
 import time
-import winreg
+
+if platform.system() == "Windows":
+    import winreg
 
 
 systemtype = platform.system()
 
 def is_metasploit_installed():
+    if platform.system() != "Windows":
+        return False
+
     uninstall_keys = [
         r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
         r"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
@@ -73,7 +78,11 @@ def check_and_install_dependencies():
     error = "[Error]: "
     info = "[Info]: "
     warning = "[Warning]: "
-    user = os.getlogin()
+    try:
+        user = os.getlogin()
+    except OSError:
+        import getpass
+        user = getpass.getuser()
     systemtype = platform.system()
 
     try:


### PR DESCRIPTION
## Summary
This PR fixes several crashes/issues encountered when running Touti-Cracker on Linux (and improves macOS behavior too):

1. **`winreg` import crash** — `scripts/dependencies_install_script.py` unconditionally imported the Windows-only `winreg` module, causing `ModuleNotFoundError` on Linux/macOS. The import is now guarded behind `platform.system() == "Windows"`, and `is_metasploit_installed()` returns `False` early on non-Windows systems.
2. **`os.getlogin()` crash** — `os.getlogin()` raises `OSError` when there is no controlling TTY (common in many Linux shells/containers). Both `main.py` and `scripts/dependencies_install_script.py` now fall back to `getpass.getuser()` when this happens.
3. **Antivirus check noise** — `is_av_active()` always shelled out to the Windows-only `sc query WinDefend | find "RUNNING"` command regardless of OS, producing `sc: not found` / `find: 'RUNNING': No such file or directory` errors on Linux and always returning a meaningless result. It's now platform-aware: it still uses `sc query` on Windows, checks common ClamAV services via `systemctl` on Linux, and checks `XProtectService` on macOS.

## Testing
- Verified `python main.py` no longer crashes on Linux and no longer prints Windows-specific shell errors.
- Verified `is_av_active()`, `is_admin()`, and the dependency installer import/run cleanly on Linux.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>